### PR TITLE
The most significant changes involve a reorganization of the code's n…

### DIFF
--- a/CwAPI3D.Net.Bridge/CwAPI3D.Net.Bridge.vcxproj.filters
+++ b/CwAPI3D.Net.Bridge/CwAPI3D.Net.Bridge.vcxproj.filters
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="src\BimController.cpp" />
+    <ClCompile Include="src\CameraData.cpp" />
+    <ClCompile Include="src\CwApi3DFactory.cpp" />
+    <ClCompile Include="src\dllmain.cpp" />
+    <ClCompile Include="src\EBimIfcType.cpp" />
+    <ClCompile Include="src\ElementController.cpp" />
+    <ClCompile Include="src\IfcTypeMapper.cpp" />
+    <ClCompile Include="src\UtilityController.cpp" />
+    <ClCompile Include="src\VisualizationController.cpp" />
+    <ClCompile Include="src\AttributeController.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="src\ApiUtils.h" />
+    <ClInclude Include="src\BimController.h" />
+    <ClInclude Include="src\CameraData.h" />
+    <ClInclude Include="src\CwApi3DFactory.h" />
+    <ClInclude Include="src\EBimIfcType.h" />
+    <ClInclude Include="src\ElementController.h" />
+    <ClInclude Include="src\IfcTypeMapper.h" />
+    <ClInclude Include="src\typedefs.h" />
+    <ClInclude Include="src\UtilityController.h" />
+    <ClInclude Include="src\vector3D.h" />
+    <ClInclude Include="src\VisualizationController.h" />
+    <ClInclude Include="src\AttributeController.h" />
+  </ItemGroup>
+</Project>

--- a/CwAPI3D.Net.Bridge/src/AttributeController.cpp
+++ b/CwAPI3D.Net.Bridge/src/AttributeController.cpp
@@ -2,7 +2,7 @@
 
 #include <stdexcept>
 
-CwAPI3D_Net::AttributeController::AttributeController(System::IntPtr aFactoryPtr)
+CwAPI3D::Net::Bridge::AttributeController::AttributeController(System::IntPtr aFactoryPtr)
 {
 	if(aFactoryPtr == System::IntPtr::Zero)
 	{
@@ -16,15 +16,17 @@ CwAPI3D_Net::AttributeController::AttributeController(System::IntPtr aFactoryPtr
 	mAttributeController = lControllerFactory->getAttributeController();
 }
 
-CwAPI3D_Net::AttributeController::~AttributeController()
+CwAPI3D::Net::Bridge::AttributeController::~AttributeController()
 {
 	this->!AttributeController();
 }
 
-CwAPI3D_Net::AttributeController::!AttributeController() { }
+CwAPI3D::Net::Bridge::AttributeController::!AttributeController() { }
 
-String ^ CwAPI3D_Net::AttributeController::getName(const elementId aElementId)
+System::String^ CwAPI3D::Net::Bridge::AttributeController::getName(elementId aElementId)
 {
 	const auto lName = mAttributeController->getName(static_cast<uint64_t>(aElementId));
-	return gcnew String(lName->data());
+	return gcnew System::String(lName->data());
 }
+
+

--- a/CwAPI3D.Net.Bridge/src/AttributeController.h
+++ b/CwAPI3D.Net.Bridge/src/AttributeController.h
@@ -3,9 +3,7 @@
 #include "CwAPI3D.h"
 #include "IAttributeController.h"
 
-using namespace System;
-
-namespace CwAPI3D_Net
+namespace CwAPI3D::Net::Bridge
 {
 public
 	ref class AttributeController sealed : public IAttributeController
@@ -19,6 +17,6 @@ public
 
 		!AttributeController();
 
-		virtual String ^ getName(elementId aElementId);
+		virtual System::String ^ getName(elementId aElementId);
 	};
-} // namespace CwAPI3D_Net
+} // namespace CwAPI3D::Net::Bridge

--- a/CwAPI3D.Net.Bridge/src/BimController.cpp
+++ b/CwAPI3D.Net.Bridge/src/BimController.cpp
@@ -5,7 +5,7 @@
 #include "IfcTypeMapper.h"
 #include <msclr/marshal_cppstd.h>
 
-CwAPI3D_Net::BimController::BimController(System::IntPtr aFactoryPtr)
+CwAPI3D::Net::Bridge::BimController::BimController(System::IntPtr aFactoryPtr)
 {
 	if(aFactoryPtr == System::IntPtr::Zero)
 	{
@@ -15,27 +15,27 @@ CwAPI3D_Net::BimController::BimController(System::IntPtr aFactoryPtr)
 	mBimController = lControllerFactory->getBimController();
 }
 
-String ^ CwAPI3D_Net::BimController::getIfcTypeDisplayString(const elementId aElementId)
+System::String ^ CwAPI3D::Net::Bridge::BimController::getIfcTypeDisplayString(const elementId aElementId)
 {
 	const auto lIfcType = mBimController->getIfc2x3ElementType(aElementId);
 	const auto lIfcTypeString = mBimController->getIfc2x3ElementTypeDisplayString(lIfcType);
-	return gcnew String(lIfcTypeString->data());
+	return gcnew System::String(lIfcTypeString->data());
 }
 
-elementId CwAPI3D_Net::BimController::getElementIdFromIfcBase64Guid(String ^ aIfcBase64Guid)
+elementId CwAPI3D::Net::Bridge::BimController::getElementIdFromIfcBase64Guid(System::String ^ aIfcBase64Guid)
 {
 	const std::wstring lNativeString = msclr::interop::marshal_as<std::wstring>(aIfcBase64Guid);
 	return static_cast<int>(mBimController->getElementIdFromIfcBase64Guid(lNativeString.c_str()));
 }
 
-String ^ CwAPI3D_Net::BimController::getIfcBase64Guid(const elementId aElementId)
+System::String ^ CwAPI3D::Net::Bridge::BimController::getIfcBase64Guid(const elementId aElementId)
 {
 	const auto lIfcBase64Guid = mBimController->getIfcBase64Guid(aElementId);
-	return gcnew String(lIfcBase64Guid->data());
+	return gcnew System::String(lIfcBase64Guid->data());
 }
 
-CwAPI3D_Net::EBimIfcType CwAPI3D_Net::BimController::getIfcType(const elementId aElementId)
+CwAPI3D::Net::Bridge::EBimIfcType CwAPI3D::Net::Bridge::BimController::getIfcType(const elementId aElementId)
 {
 	const auto lIfcType = mBimController->getIfc2x3ElementType(aElementId);
-	return Utils::mapIfcType(lIfcType);
+	return CwAPI3D_Net::Utils::mapIfcType(lIfcType);
 }

--- a/CwAPI3D.Net.Bridge/src/BimController.h
+++ b/CwAPI3D.Net.Bridge/src/BimController.h
@@ -2,7 +2,7 @@
 #include "CwAPI3D.h"
 #include "IBimController.h"
 
-namespace CwAPI3D_Net
+namespace CwAPI3D::Net::Bridge
 {
 public
 	ref class BimController sealed : public IBimController
@@ -12,12 +12,12 @@ public
 	public:
 		explicit BimController(System::IntPtr aFactoryPtr);
 
-		virtual String ^ getIfcTypeDisplayString(elementId aElementId);
+		virtual System::String ^ getIfcTypeDisplayString(elementId aElementId);
 
-		virtual elementId getElementIdFromIfcBase64Guid(String ^ aIfcBase64Guid);
+		virtual elementId getElementIdFromIfcBase64Guid(System::String ^ aIfcBase64Guid);
 
-		virtual String ^ getIfcBase64Guid(elementId aElementId);
+		virtual System::String ^ getIfcBase64Guid(elementId aElementId);
 
 		virtual EBimIfcType getIfcType(elementId aElementId);
 	};
-} // namespace CwAPI3D_Net
+} // namespace CwAPI3D::Net::Bridge

--- a/CwAPI3D.Net.Bridge/src/CameraData.cpp
+++ b/CwAPI3D.Net.Bridge/src/CameraData.cpp
@@ -2,7 +2,7 @@
 
 #include <stdexcept>
 
-CwAPI3D_Net::CameraData::CameraData(CwAPI3D::Interfaces::ICwAPI3DCameraData* aCameraData)
+CwAPI3D::Net::Bridge::CameraData::CameraData(CwAPI3D::Interfaces::ICwAPI3DCameraData* aCameraData)
 	: mCameraDataInstance{aCameraData}
 {
 	if(!mCameraDataInstance)
@@ -11,91 +11,91 @@ CwAPI3D_Net::CameraData::CameraData(CwAPI3D::Interfaces::ICwAPI3DCameraData* aCa
 	}
 }
 
-CwAPI3D_Net::CameraData::~CameraData()
+CwAPI3D::Net::Bridge::CameraData::~CameraData()
 {
 	this->!CameraData();
 }
 
-CwAPI3D_Net::CameraData::!CameraData() { }
+CwAPI3D::Net::Bridge::CameraData::!CameraData() { }
 
-void CwAPI3D_Net::CameraData::destroy()
+void CwAPI3D::Net::Bridge::CameraData::destroy()
 {
 	mCameraDataInstance->destroy();
 }
 
-void CwAPI3D_Net::CameraData::setPosition(CwAPI3D_Net::vector3D ^ aPosition)
+void CwAPI3D::Net::Bridge::CameraData::setPosition(vector3D ^ aPosition)
 {
 	mCameraDataInstance->setPosition({aPosition->X, aPosition->Y, aPosition->Z});
 }
 
-CwAPI3D_Net::vector3D ^ CwAPI3D_Net::CameraData::getPosition()
+CwAPI3D::Net::Bridge::vector3D ^ CwAPI3D::Net::Bridge::CameraData::getPosition()
 {
 	const auto [mX, mY, mZ] = mCameraDataInstance->getPosition();
-	return gcnew CwAPI3D_Net::vector3D{mX, mY, mZ};
+	return gcnew vector3D{mX, mY, mZ};
 }
 
-void CwAPI3D_Net::CameraData::setTarget(CwAPI3D_Net::vector3D ^ aTarget)
+void CwAPI3D::Net::Bridge::CameraData::setTarget(vector3D ^ aTarget)
 {
 	mCameraDataInstance->setTarget({aTarget->X, aTarget->Y, aTarget->Z});
 }
 
-CwAPI3D_Net::vector3D ^ CwAPI3D_Net::CameraData::getTarget()
+CwAPI3D::Net::Bridge::vector3D ^ CwAPI3D::Net::Bridge::CameraData::getTarget()
 {
 	const auto [mX, mY, mZ] = mCameraDataInstance->getTarget();
-	return gcnew CwAPI3D_Net::vector3D{mX, mY, mZ};
+	return gcnew vector3D{mX, mY, mZ};
 }
 
-void CwAPI3D_Net::CameraData::setUp(CwAPI3D_Net::vector3D ^ aUp)
+void CwAPI3D::Net::Bridge::CameraData::setUp(vector3D ^ aUp)
 {
 	mCameraDataInstance->setUpVector({aUp->X, aUp->Y, aUp->Z});
 }
 
-CwAPI3D_Net::vector3D ^ CwAPI3D_Net::CameraData::getUp()
+CwAPI3D::Net::Bridge::vector3D ^ CwAPI3D::Net::Bridge::CameraData::getUp()
 {
 	const auto [mX, mY, mZ] = mCameraDataInstance->getUpVector();
-	return gcnew CwAPI3D_Net::vector3D{mX, mY, mZ};
+	return gcnew vector3D{mX, mY, mZ};
 }
 
-void CwAPI3D_Net::CameraData::setProjectionType(ICameraData::projectionType aProjectionType)
+void CwAPI3D::Net::Bridge::CameraData::setProjectionType(ICameraData::projectionType aProjectionType)
 {
 	mCameraDataInstance->setProjectionType(aProjectionType == ICameraData::projectionType::perspective
 											   ? CwAPI3D::Interfaces::ICwAPI3DCameraData::Perspective
 											   : CwAPI3D::Interfaces::ICwAPI3DCameraData::Orthographic);
 }
 
-CwAPI3D_Net::ICameraData::projectionType CwAPI3D_Net::CameraData::getProjectionType()
+CwAPI3D::Net::Bridge::ICameraData::projectionType CwAPI3D::Net::Bridge::CameraData::getProjectionType()
 {
 	return mCameraDataInstance->getProjectionType() == CwAPI3D::Interfaces::ICwAPI3DCameraData::Perspective
 			   ? ICameraData::projectionType::perspective
 			   : ICameraData::projectionType::orthographic;
 }
 
-void CwAPI3D_Net::CameraData::setFieldWidth(const float aFieldWidth)
+void CwAPI3D::Net::Bridge::CameraData::setFieldWidth(const float aFieldWidth)
 {
 	mCameraDataInstance->setFieldWidth(aFieldWidth);
 }
 
-float CwAPI3D_Net::CameraData::getFieldWidth()
+float CwAPI3D::Net::Bridge::CameraData::getFieldWidth()
 {
 	return mCameraDataInstance->getFieldWidth();
 }
 
-void CwAPI3D_Net::CameraData::setFieldHeight(const float aFieldHeight)
+void CwAPI3D::Net::Bridge::CameraData::setFieldHeight(const float aFieldHeight)
 {
 	mCameraDataInstance->setFieldHeight(aFieldHeight);
 }
 
-float CwAPI3D_Net::CameraData::getFieldHeight()
+float CwAPI3D::Net::Bridge::CameraData::getFieldHeight()
 {
 	return mCameraDataInstance->getFieldHeight();
 }
 
-void CwAPI3D_Net::CameraData::setFieldOfView(const double aFieldOfView)
+void CwAPI3D::Net::Bridge::CameraData::setFieldOfView(const double aFieldOfView)
 {
 	mCameraDataInstance->setFieldOfView(aFieldOfView);
 }
 
-double CwAPI3D_Net::CameraData::getFieldOfView()
+double CwAPI3D::Net::Bridge::CameraData::getFieldOfView()
 {
 	return mCameraDataInstance->getFieldOfView();
 }

--- a/CwAPI3D.Net.Bridge/src/CameraData.h
+++ b/CwAPI3D.Net.Bridge/src/CameraData.h
@@ -3,7 +3,7 @@
 #include "CwAPI3D.h"
 #include "ICameraData.h"
 
-namespace CwAPI3D_Net
+namespace CwAPI3D::Net::Bridge
 {
 public
 	ref class CameraData sealed : public ICameraData
@@ -17,14 +17,14 @@ public
 
 		virtual void destroy();
 
-		virtual void setPosition(CwAPI3D_Net::vector3D ^ aPosition);
-		virtual CwAPI3D_Net::vector3D ^ getPosition();
+		virtual void setPosition(vector3D ^ aPosition);
+		virtual vector3D ^ getPosition();
 
-		virtual void setTarget(CwAPI3D_Net::vector3D ^ aTarget);
-		virtual CwAPI3D_Net::vector3D ^ getTarget();
+		virtual void setTarget(vector3D ^ aTarget);
+		virtual vector3D ^ getTarget();
 
-		virtual void setUp(CwAPI3D_Net::vector3D ^ aUp);
-		virtual CwAPI3D_Net::vector3D ^ getUp();
+		virtual void setUp(vector3D ^ aUp);
+		virtual vector3D ^ getUp();
 
 		virtual void setProjectionType(ICameraData::projectionType aProjectionType);
 		virtual ICameraData::projectionType getProjectionType();

--- a/CwAPI3D.Net.Bridge/src/CwApi3DFactory.cpp
+++ b/CwAPI3D.Net.Bridge/src/CwApi3DFactory.cpp
@@ -9,7 +9,7 @@
 
 #include "CameraData.h"
 
-CwAPI3D_Net::CwApi3DFactory::CwApi3DFactory(System::IntPtr aFactoryPtr)
+CwAPI3D::Net::Bridge::CwApi3DFactory::CwApi3DFactory(System::IntPtr aFactoryPtr)
 {
 	if(aFactoryPtr == System::IntPtr::Zero)
 	{
@@ -22,7 +22,7 @@ CwAPI3D_Net::CwApi3DFactory::CwApi3DFactory(System::IntPtr aFactoryPtr)
 	}
 }
 
-CwAPI3D_Net::IElementController ^ CwAPI3D_Net::CwApi3DFactory::getElementController()
+CwAPI3D::Net::Bridge::IElementController ^ CwAPI3D::Net::Bridge::CwApi3DFactory::getElementController()
 {
 	if(!mElementController)
 	{
@@ -31,7 +31,7 @@ CwAPI3D_Net::IElementController ^ CwAPI3D_Net::CwApi3DFactory::getElementControl
 	return mElementController;
 }
 
-CwAPI3D_Net::IAttributeController ^ CwAPI3D_Net::CwApi3DFactory::getAttributeController()
+CwAPI3D::Net::Bridge::IAttributeController ^ CwAPI3D::Net::Bridge::CwApi3DFactory::getAttributeController()
 {
 	if(!mAttributeController)
 	{
@@ -40,7 +40,7 @@ CwAPI3D_Net::IAttributeController ^ CwAPI3D_Net::CwApi3DFactory::getAttributeCon
 	return mAttributeController;
 }
 
-CwAPI3D_Net::IUtilityController ^ CwAPI3D_Net::CwApi3DFactory::getUtilityController()
+CwAPI3D::Net::Bridge::IUtilityController ^ CwAPI3D::Net::Bridge::CwApi3DFactory::getUtilityController()
 {
 	if(!mUtilityController)
 	{
@@ -49,7 +49,7 @@ CwAPI3D_Net::IUtilityController ^ CwAPI3D_Net::CwApi3DFactory::getUtilityControl
 	return mUtilityController;
 }
 
-CwAPI3D_Net::IVisualizationController ^ CwAPI3D_Net::CwApi3DFactory::getVisualizationController()
+CwAPI3D::Net::Bridge::IVisualizationController ^ CwAPI3D::Net::Bridge::CwApi3DFactory::getVisualizationController()
 {
 	if(!mVisualizationController)
 	{
@@ -58,7 +58,7 @@ CwAPI3D_Net::IVisualizationController ^ CwAPI3D_Net::CwApi3DFactory::getVisualiz
 	return mVisualizationController;
 }
 
-CwAPI3D_Net::IBimController ^ CwAPI3D_Net::CwApi3DFactory::getBimController()
+CwAPI3D::Net::Bridge::IBimController ^ CwAPI3D::Net::Bridge::CwApi3DFactory::getBimController()
 {
 	if(!mBimController)
 	{
@@ -67,7 +67,7 @@ CwAPI3D_Net::IBimController ^ CwAPI3D_Net::CwApi3DFactory::getBimController()
 	return mBimController;
 }
 
-CwAPI3D_Net::ICameraData ^ CwAPI3D_Net::CwApi3DFactory::getCameraData()
+CwAPI3D::Net::Bridge::ICameraData ^ CwAPI3D::Net::Bridge::CwApi3DFactory::getCameraData()
 {
 	const auto lCameraData = mControllerFactory->createCameraData();
 	if(!lCameraData)

--- a/CwAPI3D.Net.Bridge/src/CwApi3DFactory.h
+++ b/CwAPI3D.Net.Bridge/src/CwApi3DFactory.h
@@ -8,7 +8,7 @@
 #include "IElementController.h"
 #include "IVisualizationController.h"
 
-namespace CwAPI3D_Net
+namespace CwAPI3D::Net::Bridge
 {
 	// clang-format off
 	public ref class CwApi3DFactory : public ICwApi3DFactory

--- a/CwAPI3D.Net.Bridge/src/EBimIfcType.h
+++ b/CwAPI3D.Net.Bridge/src/EBimIfcType.h
@@ -1,6 +1,6 @@
 #pragma once
 
-namespace CwAPI3D_Net
+namespace CwAPI3D::Net::Bridge
 {
 public
 	enum class EBimIfcType

--- a/CwAPI3D.Net.Bridge/src/ElementController.cpp
+++ b/CwAPI3D.Net.Bridge/src/ElementController.cpp
@@ -2,7 +2,7 @@
 #include "ApiUtils.h"
 #include <stdexcept>
 
-CwAPI3D_Net::ElementController::ElementController(System::IntPtr aFactoryPtr)
+CwAPI3D::Net::Bridge::ElementController::ElementController(System::IntPtr aFactoryPtr)
 {
 	if(aFactoryPtr == System::IntPtr::Zero)
 	{
@@ -16,32 +16,32 @@ CwAPI3D_Net::ElementController::ElementController(System::IntPtr aFactoryPtr)
 	mElementController = mControllerFactory->getElementController();
 }
 
-CwAPI3D_Net::ElementController::~ElementController()
+CwAPI3D::Net::Bridge::ElementController::~ElementController()
 {
 	this->!ElementController();
 }
 
-CwAPI3D_Net::ElementController::!ElementController() { }
+CwAPI3D::Net::Bridge::ElementController::!ElementController() { }
 
-List<elementId> ^ CwAPI3D_Net::ElementController::getAllIdentifiableElementIDs()
+List<elementId> ^ CwAPI3D::Net::Bridge::ElementController::getAllIdentifiableElementIDs()
 {
 	const auto lElementIds = mElementController->getAllIdentifiableElementIDs();
-	return Utils::elementVectorToList<elementId>(lElementIds);
+	return CwAPI3D_Net::Utils::elementVectorToList<elementId>(lElementIds);
 }
 
-List<elementId> ^ CwAPI3D_Net::ElementController::getActiveIdentifiableElementIDs()
+List<elementId> ^ CwAPI3D::Net::Bridge::ElementController::getActiveIdentifiableElementIDs()
 {
 	const auto lElementIds = mElementController->getActiveIdentifiableElementIDs();
-	return Utils::elementVectorToList<elementId>(lElementIds);
+	return CwAPI3D_Net::Utils::elementVectorToList<elementId>(lElementIds);
 }
 
-List<elementId> ^ CwAPI3D_Net::ElementController::getVisibleIdentifiableElementIDs()
+List<elementId> ^ CwAPI3D::Net::Bridge::ElementController::getVisibleIdentifiableElementIDs()
 {
 	const auto lElementIds = mElementController->getVisibleIdentifiableElementIDs();
-	return Utils::elementVectorToList<elementId>(lElementIds);
+	return CwAPI3D_Net::Utils::elementVectorToList<elementId>(lElementIds);
 }
 
-void CwAPI3D_Net::ElementController::addElementsToUndo(List<elementId> ^ aElementIDs, const Utils::undoType aUndoType)
+void CwAPI3D::Net::Bridge::ElementController::addElementsToUndo(List<elementId> ^ aElementIDs, const CwAPI3D_Net::Utils::undoType aUndoType)
 {
 	const auto lElementIdList = mControllerFactory->createEmptyElementIDList();
 
@@ -49,6 +49,6 @@ void CwAPI3D_Net::ElementController::addElementsToUndo(List<elementId> ^ aElemen
 	{
 		lElementIdList->append(lItem);
 	}
-	mElementController->addElementsToUndo(lElementIdList, aUndoType == Utils::undoType::add ? 1 : 2);
+	mElementController->addElementsToUndo(lElementIdList, aUndoType == CwAPI3D_Net::Utils::undoType::add ? 1 : 2);
 	lElementIdList->destroy();
 }

--- a/CwAPI3D.Net.Bridge/src/ElementController.h
+++ b/CwAPI3D.Net.Bridge/src/ElementController.h
@@ -5,7 +5,7 @@
 
 using namespace System::Collections::Generic;
 
-namespace CwAPI3D_Net
+namespace CwAPI3D::Net::Bridge
 {
 public
 	ref class ElementController sealed : public IElementController
@@ -26,6 +26,6 @@ public
 
 		virtual List<elementId> ^ getVisibleIdentifiableElementIDs();
 
-		virtual void addElementsToUndo(List<elementId> ^ aElementIDs, Utils::undoType aUndoType);
+		virtual void addElementsToUndo(List<elementId> ^ aElementIDs, CwAPI3D_Net::Utils::undoType aUndoType);
 	};
-} // namespace CwAPI3D_Net
+} // namespace CwAPI3D::Net::Bridge

--- a/CwAPI3D.Net.Bridge/src/IfcTypeMapper.cpp
+++ b/CwAPI3D.Net.Bridge/src/IfcTypeMapper.cpp
@@ -2,124 +2,124 @@
 
 #include <stdexcept>
 
-CwAPI3D_Net::EBimIfcType CwAPI3D_Net::Utils::mapIfcType(CwAPI3D::Interfaces::ICwAPI3DIfc2x3ElementType* aIfcType)
+CwAPI3D::Net::Bridge::EBimIfcType CwAPI3D_Net::Utils::mapIfcType(CwAPI3D::Interfaces::ICwAPI3DIfc2x3ElementType* aIfcType)
 {
 	if(aIfcType->isNone())
 	{
-		return EBimIfcType::none;
+		return CwAPI3D::Net::Bridge::EBimIfcType::none;
 	}
 	if(aIfcType->isIfcBeam())
 	{
-		return EBimIfcType::ifcBeam;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcBeam;
 	}
 	if(aIfcType->isIfcColumn())
 	{
-		return EBimIfcType::ifcColumn;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcColumn;
 	}
 	if(aIfcType->isIfcCurtainWall())
 	{
-		return EBimIfcType::ifcCurtainWall;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcCurtainWall;
 	}
 	if(aIfcType->isIfcDoor())
 	{
-		return EBimIfcType::ifcDoor;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcDoor;
 	}
 	if(aIfcType->isIfcMember())
 	{
-		return EBimIfcType::ifcMember;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcMember;
 	}
 	if(aIfcType->isIfcPlate())
 	{
-		return EBimIfcType::ifcPlate;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcPlate;
 	}
 	if(aIfcType->isIfcRailing())
 	{
-		return EBimIfcType::ifcRailing;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcRailing;
 	}
 	if(aIfcType->isIfcRamp())
 	{
-		return EBimIfcType::ifcRamp;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcRamp;
 	}
 	if(aIfcType->isIfcRampFlight())
 	{
-		return EBimIfcType::ifcRampFlight;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcRampFlight;
 	}
 	if(aIfcType->isIfcRoof())
 	{
-		return EBimIfcType::ifcRoof;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcRoof;
 	}
 	if(aIfcType->isIfcSlab())
 	{
-		return EBimIfcType::ifcSlab;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcSlab;
 	}
 	if(aIfcType->isIfcStair())
 	{
-		return EBimIfcType::ifcStair;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcStair;
 	}
 	if(aIfcType->isIfcStairFlight())
 	{
-		return EBimIfcType::ifcStairFlight;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcStairFlight;
 	}
 	if(aIfcType->isIfcWall())
 	{
-		return EBimIfcType::ifcWall;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcWall;
 	}
 	if(aIfcType->isIfcWallStandardCase())
 	{
-		return EBimIfcType::ifcWallStandardCase;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcWallStandardCase;
 	}
 	if(aIfcType->isIfcWindow())
 	{
-		return EBimIfcType::ifcWindow;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcWindow;
 	}
 	if(aIfcType->isIfcBuildingElementProxy())
 	{
-		return EBimIfcType::ifcBuildingElementProxy;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcBuildingElementProxy;
 	}
 	if(aIfcType->isIfcChimney())
 	{
-		return EBimIfcType::ifcChimney;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcChimney;
 	}
 	if(aIfcType->isIfcCovering())
 	{
-		return EBimIfcType::ifcCovering;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcCovering;
 	}
 	if(aIfcType->isIfcFooting())
 	{
-		return EBimIfcType::ifcFooting;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcFooting;
 	}
 	if(aIfcType->isIfcFurnishingElement())
 	{
-		return EBimIfcType::ifcFurnishingElement;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcFurnishingElement;
 	}
 	if(aIfcType->isIfcOpeningElement())
 	{
-		return EBimIfcType::ifcOpeningElement;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcOpeningElement;
 	}
 	if(aIfcType->isIfcSpace())
 	{
-		return EBimIfcType::ifcSpace;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcSpace;
 	}
 	if(aIfcType->isIfcFlowSegment())
 	{
-		return EBimIfcType::ifcFlowSegment;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcFlowSegment;
 	}
 	if(aIfcType->isIfcBuildingElementPart())
 	{
-		return EBimIfcType::ifcBuildingElementPart;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcBuildingElementPart;
 	}
 	if(aIfcType->isIfcDiscreteAccessory())
 	{
-		return EBimIfcType::ifcDiscreteAccessory;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcDiscreteAccessory;
 	}
 	if(aIfcType->isIfcFastener())
 	{
-		return EBimIfcType::ifcFastener;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcFastener;
 	}
 	if(aIfcType->isIfcMechanicalFastener())
 	{
-		return EBimIfcType::ifcMechanicalFastener;
+		return CwAPI3D::Net::Bridge::EBimIfcType::ifcMechanicalFastener;
 	}
 	// throw std::runtime_error("Unknown IFC type");
-	return EBimIfcType::none;
+	return CwAPI3D::Net::Bridge::EBimIfcType::none;
 }

--- a/CwAPI3D.Net.Bridge/src/IfcTypeMapper.h
+++ b/CwAPI3D.Net.Bridge/src/IfcTypeMapper.h
@@ -5,5 +5,5 @@
 
 namespace CwAPI3D_Net::Utils
 {
-	EBimIfcType mapIfcType(CwAPI3D::Interfaces::ICwAPI3DIfc2x3ElementType* aIfcType);
+	CwAPI3D::Net::Bridge::EBimIfcType mapIfcType(CwAPI3D::Interfaces::ICwAPI3DIfc2x3ElementType* aIfcType);
 }

--- a/CwAPI3D.Net.Bridge/src/UtilityController.cpp
+++ b/CwAPI3D.Net.Bridge/src/UtilityController.cpp
@@ -4,7 +4,7 @@
 
 #include "vector3D.h"
 
-CwAPI3D_Net::UtilityController::UtilityController(System::IntPtr aFactoryPtr)
+CwAPI3D::Net::Bridge::UtilityController::UtilityController(System::IntPtr aFactoryPtr)
 {
 	if(aFactoryPtr == System::IntPtr::Zero)
 	{
@@ -18,55 +18,55 @@ CwAPI3D_Net::UtilityController::UtilityController(System::IntPtr aFactoryPtr)
 	mUtilityController = lControllerFactory->getUtilityController();
 }
 
-CwAPI3D_Net::UtilityController::~UtilityController()
+CwAPI3D::Net::Bridge::UtilityController::~UtilityController()
 {
 	this->!UtilityController();
 }
 
-CwAPI3D_Net::UtilityController::!UtilityController() { }
+CwAPI3D::Net::Bridge::UtilityController::!UtilityController() { }
 
-String ^ CwAPI3D_Net::UtilityController::getPluginPath()
+System::String ^ CwAPI3D::Net::Bridge::UtilityController::getPluginPath()
 {
 	const auto lPath = mUtilityController->getPluginPath();
-	return gcnew String(lPath->data());
+	return gcnew System::String(lPath->data());
 }
 
-bool CwAPI3D_Net::UtilityController::getUseOfGlobalCoordinates()
+bool CwAPI3D::Net::Bridge::UtilityController::getUseOfGlobalCoordinates()
 {
 	return mUtilityController->getUseOfGlobalCoordinates();
 }
 
-CwAPI3D_Net::vector3D ^ CwAPI3D_Net::UtilityController::getGlobalOrigin()
+CwAPI3D::Net::Bridge::vector3D ^ CwAPI3D::Net::Bridge::UtilityController::getGlobalOrigin()
 {
 	const auto [mX, mY, mZ] = mUtilityController->getGlobalOrigin();
 	return gcnew vector3D(mX, mY, mZ);
 }
 
-String ^ CwAPI3D_Net::UtilityController::createSnapshot(String ^ aFormat, const int aQuality, const bool aWhiteBackground)
+System::String ^ CwAPI3D::Net::Bridge::UtilityController::createSnapshot(System::String ^ aFormat, const int aQuality, const bool aWhiteBackground)
 {
 	const std::wstring lNativeString = msclr::interop::marshal_as<std::wstring>(aFormat);
 	const auto lSnapshot = mUtilityController->createSnapshot(lNativeString.c_str(), aQuality, aWhiteBackground);
-	return gcnew String(lSnapshot->data());
+	return gcnew System::String(lSnapshot->data());
 }
 
-void CwAPI3D_Net::UtilityController::disableAutoDisplayRefresh()
+void CwAPI3D::Net::Bridge::UtilityController::disableAutoDisplayRefresh()
 {
 	mUtilityController->disableAutoDisplayRefresh();
 }
 
-void CwAPI3D_Net::UtilityController::enableAutoDisplayRefresh()
+void CwAPI3D::Net::Bridge::UtilityController::enableAutoDisplayRefresh()
 {
 	mUtilityController->enableAutoDisplayRefresh();
 }
 
-Tuple<int, int> ^ CwAPI3D_Net::UtilityController::get3dGuiUpperLeftScreenCoordinates()
+System::Tuple<int, int> ^ CwAPI3D::Net::Bridge::UtilityController::get3dGuiUpperLeftScreenCoordinates()
 {
 	const auto [mX, mY] = mUtilityController->get3dGuiUpperLeftScreenCoordinates();
-	return gcnew Tuple<int, int>(static_cast<int>(mX), static_cast<int>(mY));
+	return gcnew System::Tuple<int, int>(static_cast<int>(mX), static_cast<int>(mY));
 }
 
-String ^ CwAPI3D_Net::UtilityController::getLanguage()
+System::String ^ CwAPI3D::Net::Bridge::UtilityController::getLanguage()
 {
 	const auto lLanguageString = mUtilityController->getLanguage();
-	return gcnew String(lLanguageString->data());
+	return gcnew System::String(lLanguageString->data());
 }

--- a/CwAPI3D.Net.Bridge/src/UtilityController.h
+++ b/CwAPI3D.Net.Bridge/src/UtilityController.h
@@ -4,9 +4,7 @@
 
 #include "IUtilityController.h"
 
-using namespace System;
-
-namespace CwAPI3D_Net
+namespace CwAPI3D::Net::Bridge
 {
 
 public
@@ -20,13 +18,13 @@ public
 
 		!UtilityController();
 
-		virtual String ^ getPluginPath();
+		virtual System::String ^ getPluginPath();
 		virtual bool getUseOfGlobalCoordinates();
 		virtual vector3D ^ getGlobalOrigin();
-		virtual String ^ createSnapshot(String ^ aFormat, int aQuality, bool aWhiteBackground);
+		virtual System::String ^ createSnapshot(System::String ^ aFormat, int aQuality, bool aWhiteBackground);
 		virtual void disableAutoDisplayRefresh();
 		virtual void enableAutoDisplayRefresh();
-		virtual Tuple<int, int> ^ get3dGuiUpperLeftScreenCoordinates();
-		virtual String ^ getLanguage();
+		virtual System::Tuple<int, int> ^ get3dGuiUpperLeftScreenCoordinates();
+		virtual System::String ^ getLanguage();
 	};
 } // namespace CwAPI3D_Net

--- a/CwAPI3D.Net.Bridge/src/VisualizationController.cpp
+++ b/CwAPI3D.Net.Bridge/src/VisualizationController.cpp
@@ -4,7 +4,7 @@
 
 #include "CameraData.h"
 
-CwAPI3D_Net::VisualizationController::VisualizationController(System::IntPtr aFactoryPtr)
+CwAPI3D::Net::Bridge::VisualizationController::VisualizationController(System::IntPtr aFactoryPtr)
 {
 	if(aFactoryPtr == System::IntPtr::Zero)
 	{
@@ -18,21 +18,21 @@ CwAPI3D_Net::VisualizationController::VisualizationController(System::IntPtr aFa
 	mVisualizationController = mControllerFactory->getVisualizationController();
 }
 
-CwAPI3D_Net::VisualizationController::~VisualizationController()
+CwAPI3D::Net::Bridge::VisualizationController::~VisualizationController()
 {
 	this->!VisualizationController();
 }
 
-CwAPI3D_Net::VisualizationController::!VisualizationController()
+CwAPI3D::Net::Bridge::VisualizationController::!VisualizationController()
 {
 }
 
-bool CwAPI3D_Net::VisualizationController::isActive(int aElementID)
+bool CwAPI3D::Net::Bridge::VisualizationController::isActive(int aElementID)
 {
 	return mVisualizationController->isActive(aElementID);
 }
 
-void CwAPI3D_Net::VisualizationController::setActive(List<int> ^ aElementIDs)
+void CwAPI3D::Net::Bridge::VisualizationController::setActive(List<int> ^ aElementIDs)
 {
 	const auto lElementIDList = mControllerFactory->createEmptyElementIDList();
 	for each(int aElementID in aElementIDs)
@@ -42,7 +42,7 @@ void CwAPI3D_Net::VisualizationController::setActive(List<int> ^ aElementIDs)
 	mVisualizationController->setActive(lElementIDList);
 }
 
-void CwAPI3D_Net::VisualizationController::setInActive(List<int> ^ aElementIDs)
+void CwAPI3D::Net::Bridge::VisualizationController::setInActive(List<int> ^ aElementIDs)
 {
 	const auto lElementIDList = mControllerFactory->createEmptyElementIDList();
 	for each(int aElementID in aElementIDs)
@@ -52,12 +52,12 @@ void CwAPI3D_Net::VisualizationController::setInActive(List<int> ^ aElementIDs)
 	mVisualizationController->setInactive(lElementIDList);
 }
 
-bool CwAPI3D_Net::VisualizationController::isVisible(int aElementID)
+bool CwAPI3D::Net::Bridge::VisualizationController::isVisible(int aElementID)
 {
 	return mVisualizationController->isVisible(aElementID);
 }
 
-void CwAPI3D_Net::VisualizationController::setVisible(List<int> ^ aElementIDs)
+void CwAPI3D::Net::Bridge::VisualizationController::setVisible(List<int> ^ aElementIDs)
 {
 	const auto lElementIDList = mControllerFactory->createEmptyElementIDList();
 	for each(int aElementID in aElementIDs)
@@ -67,22 +67,22 @@ void CwAPI3D_Net::VisualizationController::setVisible(List<int> ^ aElementIDs)
 	mVisualizationController->setVisible(lElementIDList);
 }
 
-void CwAPI3D_Net::VisualizationController::hideAllElements()
+void CwAPI3D::Net::Bridge::VisualizationController::hideAllElements()
 {
 	mVisualizationController->hideAllElements();
 }
 
-void CwAPI3D_Net::VisualizationController::showAllElements()
+void CwAPI3D::Net::Bridge::VisualizationController::showAllElements()
 {
 	mVisualizationController->showAllElements();
 }
 
-bool CwAPI3D_Net::VisualizationController::isPlane2D()
+bool CwAPI3D::Net::Bridge::VisualizationController::isPlane2D()
 {
 	return mVisualizationController->isPlane2d();
 }
 
-void CwAPI3D_Net::VisualizationController::setCamera(ICameraData ^ aCameraData)
+void CwAPI3D::Net::Bridge::VisualizationController::setCamera(ICameraData ^ aCameraData)
 {
 	const auto lCameraData = mControllerFactory->createCameraData();
 
@@ -97,12 +97,12 @@ void CwAPI3D_Net::VisualizationController::setCamera(ICameraData ^ aCameraData)
 	mVisualizationController->setCameraData(lCameraData);
 }
 
-CwAPI3D_Net::ICameraData ^ CwAPI3D_Net::VisualizationController::getCamera()
+CwAPI3D::Net::Bridge::ICameraData ^ CwAPI3D::Net::Bridge::VisualizationController::getCamera()
 {
 	return gcnew CameraData(mVisualizationController->getCameraData());
 }
 
-void CwAPI3D_Net::VisualizationController::refresh()
+void CwAPI3D::Net::Bridge::VisualizationController::refresh()
 {
 	mVisualizationController->refresh();
 }

--- a/CwAPI3D.Net.Bridge/src/VisualizationController.h
+++ b/CwAPI3D.Net.Bridge/src/VisualizationController.h
@@ -2,7 +2,7 @@
 #include "CwAPI3D.h"
 #include "IVisualizationController.h"
 
-namespace CwAPI3D_Net
+namespace CwAPI3D::Net::Bridge
 {
 public
 	ref class VisualizationController sealed : public IVisualizationController

--- a/CwAPI3D.Net.Bridge/src/vector3D.h
+++ b/CwAPI3D.Net.Bridge/src/vector3D.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <cmath>
 
-namespace CwAPI3D_Net
+namespace CwAPI3D::Net::Bridge
 {
 public
 	ref class vector3D

--- a/Interfaces/IAttributeController.h
+++ b/Interfaces/IAttributeController.h
@@ -2,13 +2,11 @@
 
 #include "typedefs.h"
 
-using namespace System;
-
-namespace CwAPI3D_Net
+namespace CwAPI3D::Net::Bridge
 {
 public
 	interface class IAttributeController
 	{
-		String ^ getName(elementId aElementID);
+		System::String ^ getName(elementId aElementID);
 	};
 } // namespace CwAPI3D_Net

--- a/Interfaces/IBimController.h
+++ b/Interfaces/IBimController.h
@@ -2,19 +2,17 @@
 #include "EBimIfcType.h"
 #include "typedefs.h"
 
-using namespace System;
-
-namespace CwAPI3D_Net
+namespace CwAPI3D::Net::Bridge
 {
 public
 	interface class IBimController
 	{
 		EBimIfcType getIfcType(elementId aElementId);
 
-		String ^ getIfcTypeDisplayString(elementId aElementId);
+		System::String ^ getIfcTypeDisplayString(elementId aElementId);
 
-		elementId getElementIdFromIfcBase64Guid(String ^ aIfcBase64Guid);
+		elementId getElementIdFromIfcBase64Guid(System::String ^ aIfcBase64Guid);
 
-		String ^ getIfcBase64Guid(elementId aElementId);
+		System::String ^ getIfcBase64Guid(elementId aElementId);
 	};
 } // namespace CwAPI3D_Net

--- a/Interfaces/ICameraData.h
+++ b/Interfaces/ICameraData.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "vector3D.h"
 
-namespace CwAPI3D_Net
+namespace CwAPI3D::Net::Bridge
 {
 public
 	interface class ICameraData
@@ -14,14 +14,14 @@ public
 
 		void destroy();
 
-		void setPosition(CwAPI3D_Net::vector3D ^ aPosition);
-		CwAPI3D_Net::vector3D ^ getPosition();
+		void setPosition(vector3D ^ aPosition);
+		vector3D ^ getPosition();
 
-		void setTarget(CwAPI3D_Net::vector3D ^ aTarget);
-		CwAPI3D_Net::vector3D ^ getTarget();
+		void setTarget(vector3D ^ aTarget);
+		vector3D ^ getTarget();
 
-		void setUp(CwAPI3D_Net::vector3D ^ aUp);
-		CwAPI3D_Net::vector3D ^ getUp();
+		void setUp(vector3D ^ aUp);
+		vector3D ^ getUp();
 
 		void setProjectionType(projectionType aProjectionType);
 		projectionType getProjectionType();

--- a/Interfaces/ICwApi3DFactory.h
+++ b/Interfaces/ICwApi3DFactory.h
@@ -3,7 +3,7 @@
 #include "IBimController.h"
 #include "IVisualizationController.h"
 
-namespace CwAPI3D_Net
+namespace CwAPI3D::Net::Bridge
 {
 	interface class IElementController;
 	interface class IAttributeController;

--- a/Interfaces/IElementController.h
+++ b/Interfaces/IElementController.h
@@ -4,7 +4,7 @@
 
 using namespace System::Collections::Generic;
 
-namespace CwAPI3D_Net
+namespace CwAPI3D::Net::Bridge
 {
 public
 	interface class IElementController
@@ -15,6 +15,6 @@ public
 
 		List<elementId> ^ getActiveIdentifiableElementIDs();
 
-		void addElementsToUndo(List<elementId> ^ aElementIDs, Utils::undoType aUndoType);
+		void addElementsToUndo(List<elementId> ^ aElementIDs, CwAPI3D_Net::Utils::undoType aUndoType);
 	};
 } // namespace CwAPI3D_Net

--- a/Interfaces/IUtilityController.h
+++ b/Interfaces/IUtilityController.h
@@ -1,27 +1,25 @@
 #pragma once
 
-using namespace System;
-
-namespace CwAPI3D_Net
+namespace CwAPI3D::Net::Bridge
 {
 	ref class vector3D;
 public
 	interface class IUtilityController
 	{
-		String ^ getPluginPath();
+		System::String ^ getPluginPath();
 
 		bool getUseOfGlobalCoordinates();
 
 		vector3D ^ getGlobalOrigin();
 
-		String ^ createSnapshot(String ^ aFormat, int aQuality, bool aWhiteBackground);
+		System::String ^ createSnapshot(System::String ^ aFormat, int aQuality, bool aWhiteBackground);
 
 		void disableAutoDisplayRefresh();
 
 		void enableAutoDisplayRefresh();
 
-		Tuple<int, int> ^ get3dGuiUpperLeftScreenCoordinates();
+		System::Tuple<int, int> ^ get3dGuiUpperLeftScreenCoordinates();
 
-		String ^ getLanguage();
+		System::String ^ getLanguage();
 	};
 } // namespace CwAPI3D_Net

--- a/Interfaces/IVisualizationController.h
+++ b/Interfaces/IVisualizationController.h
@@ -3,7 +3,7 @@
 
 using namespace System::Collections::Generic;
 
-namespace CwAPI3D_Net
+namespace CwAPI3D::Net::Bridge
 {
 public
 	interface class IVisualizationController

--- a/examplelib/Initializer.cs
+++ b/examplelib/Initializer.cs
@@ -1,22 +1,43 @@
 ﻿using System;
+using System.Linq;
 
 namespace examplelib
 {
+
+  public delegate void OnSomeOperation(String aString);
   public class Initializer
   {
-    private static CwAPI3D_Net.ICwApi3DFactory _mControllerFactory;
+    private static CwAPI3D.Net.Bridge.ICwApi3DFactory _mControllerFactory;
     public static bool Initialize(IntPtr aFactoryPointer)
     {
       if (aFactoryPointer == IntPtr.Zero)
       {
         return false;
       }
-      _mControllerFactory = new CwAPI3D_Net.CwApi3DFactory(aFactoryPointer);
+      _mControllerFactory = new CwAPI3D.Net.Bridge.CwApi3DFactory(aFactoryPointer);
 
       var lActiveElementIds = _mControllerFactory.getElementController().getActiveIdentifiableElementIDs();
+      if (lActiveElementIds == null)
+      {
+        return false;
+      }
 
-      lActiveElementIds?.ForEach(PrintElementNameToConsole);
+      lActiveElementIds.ForEach(PrintElementNameToConsole);
 
+      Action<string> action = name =>
+      {
+        string greeting = $"Hello, {name}!";
+        Console.WriteLine(greeting);
+      };
+      action(lActiveElementIds.Any() ? 
+        _mControllerFactory.getAttributeController().getName(lActiveElementIds[0]) 
+        : "World");
+
+      OnSomeOperation handler = (String aString) => { Console.WriteLine(aString); };
+      handler("delegate method");
+
+      Func<int, int, bool> function = (a, b) => a > b;
+      Console.WriteLine(function(1, 2));
 
       return true;
     }

--- a/examplelib/examplelib.csproj
+++ b/examplelib/examplelib.csproj
@@ -49,13 +49,13 @@
   <ItemGroup>
     <ProjectReference Include="..\CwAPI3D.Net.Bridge\CwAPI3D.Net.Bridge.vcxproj">
       <Project>{d7afeb12-6630-40fe-a8e1-bed9c0238ab8}</Project>
-      <Name>CwAPI3D_CSharp</Name>
+      <Name>CwAPI3D.Net.Bridge</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>if exist "D:\cadwork\userprofil_30\3d\API.x64\CwAPI3D_CSharp" (
-  xcopy /y "$(TargetPath)" "D:\cadwork\userprofil_30\3d\API.x64\CwAPI3D_CSharp"
+    <PostBuildEvent>if exist "D:\cadwork\userprofil_30\3d\API.x64\CwAPI3D.Net.Bridge" (
+  xcopy /y "$(TargetPath)" "D:\cadwork\userprofil_30\3d\API.x64\CwAPI3D.Net.Bridge"
 ) else (
   echo "Destination directory does not exist, skipping copy."
 )</PostBuildEvent>


### PR DESCRIPTION
…amespace structure. The namespace `CwAPI3D_Net` has been changed to `CwAPI3D::Net::Bridge` across multiple files, which is likely to improve code organization and readability. This change has also been reflected in the renaming of several classes, functions, and types. For instance, the `CwAPI3D_Net::Utils::mapIfcType` function has been changed to `CwAPI3D_Net::Utils::mapIfcType`, and the `CwAPI3D_Net::vector3D` type has been replaced with `vector3D`.